### PR TITLE
chore: add jsdoc style function header

### DIFF
--- a/src/2-fetchJSON.js
+++ b/src/2-fetchJSON.js
@@ -1,3 +1,8 @@
+/** 
+ * Fetch Card from metabase instance.
+ * @param {number} id - id of a metabase card
+ * @returns {string} - card data as json string
+ */
 async function fetchCardIdJSON(id = 29) {
   const config = {
     muteHttpExceptions: true,


### PR DESCRIPTION
Since javascript/googlescript is a language using _dynamic typing_, it can be hard to tell what is the _type_ of argument a function is expecting or returning.  

Annotating our function signatures with **JSDoc style comments** would let our IDE (in this example: visual studio) automatically create information boxes with relevant information and help correct us if we try passing invalid arguments to annotated functions.

https://www.valentinog.com/blog/jsdoc/

![image](https://user-images.githubusercontent.com/115998057/202234849-3e308994-5e4f-4132-a77a-739fadbd88ae.png)
