### PR TITLE
Docs Update: Free Metabase instance setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,32 +22,32 @@ After the setup, the library proved the additional `Metabase` menu in the Spread
 
 ## Dev Env Setup
 
-1. Clone the repository
+1.  Clone the repository
 
         git clone git@github.com/CorrelAid/metabase-to-google.git
 
-1. Install dependencies
+1.  Install dependencies
 
         npm install
 
-1. Create clasp configuration file
+1.  Create clasp configuration file
 
         cp .clasp.json.example .clasp.json
 
-1. Create a google apps script project [here](https://script.google.com/home). **NOTE**: You have to [enable Google Apps Script for your user](https://script.google.com/home/usersettings) if you haven't done it already.
+1.  Create a google apps script project [here](https://script.google.com/home). **NOTE**: You have to [enable Google Apps Script for your user](https://script.google.com/home/usersettings) if you haven't done it already.
 
-1. Update `.clasp.json` with the fill path to the `src` folder and with a google script ID for a
+1.  Update `.clasp.json` with the fill path to the `src` folder and with a google script ID for a
     standalone script.
 
-1. Sign into google with clasp.
+1.  Sign into google with clasp.
 
         clasp login
 
-1. Push the local project to google apps script.
+1.  Push the local project to google apps script.
 
         clasp push
 
-1. Configure google apps script properties (key-value pairs).
+1.  Configure google apps script properties (key-value pairs).
 
     - `clasp open`
     - got to "Project Settings"
@@ -130,9 +130,11 @@ setup (see [above](#pre-commit-setup)).
 
 In case you want to quickly setup a Metabase instance for testing purposes (or for operating it on a relatively low budget for the duration of a project), a few beginner-friendly alternatives exist:
 
-> However, both services require you to provide credit card / payment details despite the free-tier tracks
+> However, such services may require you to provide credit card / payment details despite the free-tier tracks. Even if they don't such requirements change frequently for
 
-- `Railway.app` (🔗 [https://railway.app/](https://railway.app/)) is a Heroku-like service and offers a free-tier (5€ free budget / 500 hours free per month). They provide a [🔗 1-click setup template for Metabase](https://railway.app/new/template/L22H6p). The template itself is [documented here](https://railway.app/template/L22H6p).
+    free tiers.
+
+- `Railway.app` (🔗 [https://railway.app/](https://railway.app/)) is a Heroku-like service and offers a free-tier (5€ free budget / 500 hours free per month). They provide a [🔗 1-click setup template for Metabase](https://railway.app/new/template/L22H6p). The template itself is [documented here](https://railway.app/template/L22H6p). (As of March 23, no credit card required)
 - `Render.com` (🔗 [https://render.com/](https://render.com/)) is a bit more complex than Railway but offers similar services, as well as a free tier (750 free hours / month). They also provide a [1-click deploy template for metabase](https://render.com/docs/deploy-metabase). On the free tier, Render will sent inactive instances to sleep after 15 minutes, so that there might be a delay of 30 seconds for each cold start / resuming activities.
 
 These two approaches should be sufficient to quickly spin up your own Metabase instance. If you've identified another beginner-friendly approach, please extend this list by submitting a pull request.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ saved Metabase queries (called cards in Metabase) through the
 The goal is to make it easy to keep the exported Metabase data in the spreadsheets up date.
 Currently this is done by making updates very easy, but in the future it might even be automated entirely ('live-connected').
 
+> See [Metabase Test Instance Setup](#metabase-test-instance-setup) for instructions on how to quickly setup your own Metabase instance.
+
 ## This Repository
 
 This repository contains JavaScript code that is intended to be deployed as a Google Apps script library, which in turn should be used in a containerized script of a Google SpreadSheet. Detailed setup instructions are found [below](#control-sheet-setup).
@@ -123,3 +125,14 @@ them on the source folder.
 All three quality assurance tools together for our CI checks. This means CI should pass if
 these three checks pass locally. Additionally formatting and linting are part of the pre-commit hook
 setup (see [above](#pre-commit-setup)).
+
+## Metabase Test Instance Setup
+
+In case you want to quickly setup a Metabase instance for testing purposes (or for operating it on a relatively low budget for the duration of a project), a few beginner-friendly alternatives exist:
+
+> However, both services require you to provide credit card / payment details despite the free-tier tracks
+
+- `Railway.app` (🔗 [https://railway.app/](https://railway.app/)) is a Heroku-like service and offers a free-tier (5€ free budget / 500 hours free per month). They provide a [🔗 1-click setup template for Metabase](https://railway.app/new/template/L22H6p). The template itself is [documented here](https://railway.app/template/L22H6p).
+- `Render.com` (🔗 [https://render.com/](https://render.com/)) is a bit more complex than Railway but offers similar services, as well as a free tier (750 free hours / month). They also provide a [1-click deploy template for metabase](https://render.com/docs/deploy-metabase). On the free tier, Render will sent inactive instances to sleep after 15 minutes, so that there might be a delay of 30 seconds for each cold start / resuming activities.
+
+These two approaches should be sufficient to quickly spin up your own Metabase instance. If you've identified another beginner-friendly approach, please extend this list by submitting a pull request.

--- a/README.md
+++ b/README.md
@@ -20,32 +20,32 @@ After the setup, the library proved the additional `Metabase` menu in the Spread
 
 ## Dev Env Setup
 
-1.  Clone the repository
+1. Clone the repository
 
         git clone git@github.com/CorrelAid/metabase-to-google.git
 
-1.  Install dependencies
+1. Install dependencies
 
         npm install
 
-1.  Create clasp configuration file
+1. Create clasp configuration file
 
         cp .clasp.json.example .clasp.json
 
-1.  Create a google apps script project [here](https://script.google.com/home). **NOTE**: You have to [enable Google Apps Script for your user](https://script.google.com/home/usersettings) if you haven't done it already.
+1. Create a google apps script project [here](https://script.google.com/home). **NOTE**: You have to [enable Google Apps Script for your user](https://script.google.com/home/usersettings) if you haven't done it already.
 
-1.  Update `.clasp.json` with the fill path to the `src` folder and with a google script ID for a
+1. Update `.clasp.json` with the fill path to the `src` folder and with a google script ID for a
     standalone script.
 
-1.  Sign into google with clasp.
+1. Sign into google with clasp.
 
         clasp login
 
-1.  Push the local project to google apps script.
+1. Push the local project to google apps script.
 
         clasp push
 
-1.  Configure google apps script properties (key-value pairs).
+1. Configure google apps script properties (key-value pairs).
 
     - `clasp open`
     - got to "Project Settings"


### PR DESCRIPTION
- docs: readme.md lint
- docs: Metabase instructions for Railway & Render

If to obstrusive, please ignore the lint / formatting applied in the first commit.

As a follow-up to this commit, I'd like to cross-link the Metabase section from the R project.
