### PR TITLE
exteded formatting scope to align with pretty-quick/husky setup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,12 +15,12 @@ jobs:
         with:
           node-version: '16'
 
-      - name: Install dependencies 
+      - name: Install dependencies
         run: |
           npm install
 
       - name: Run formatter and linter and tests
         run: |
-          npx prettier src/ --check
+          npm run format_check 
           npm run lint
           npm run test

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # Change History
 
 ## Version 0.1.0
+
 - client to connect to metabase and fetch available cards and execute them
 - custom metabase menu for Google Sheets

--- a/package.json
+++ b/package.json
@@ -9,15 +9,16 @@
   "engineStrict": true,
   "scripts": {
     "test": "npx jasmine",
-    "format": "npx prettier -w src/",
+    "format": "npx prettier -w src/ spec/ .github/ *.md package.json",
+    "format_check": "npx prettier --check src/ spec/ .github/ *.md package.json",
     "quick_format": "npx pretty-quick --staged",
-    "lint": "npx eslint --fix src/",
+    "lint": "npx eslint --fix src/ spec/",
     "precommit": "run-s quick_format lint",
     "init_pre_commit": "husky install"
   },
   "contributors": [
     "@fubits",
-    "KonradUdoHannes <konrad.woelms@gmail.com",
+    "KonradUdoHannes <konrad.woelms@gmail.com>",
     "ariaguia"
   ],
   "license": "MIT",

--- a/spec/project/ClientSpec.js
+++ b/spec/project/ClientSpec.js
@@ -1,43 +1,53 @@
 const {MetabaseClient} = require('../../src/metabase-client');
 
-describe('Client', function() {
+describe('Client', function () {
   let client;
   let userPropSpy;
   let urlFetcherSpy;
 
-  beforeEach(function() {
-    userPropSpy = jasmine.createSpyObj('userProperties',
-      {
-        'getKeys': [],
-        'getProperty': null,
-        'setProperty': null,
-      },
-    );
+  beforeEach(function () {
+    userPropSpy = jasmine.createSpyObj('userProperties', {
+      getKeys: [],
+      getProperty: null,
+      setProperty: null,
+    });
     urlFetcherSpy = jasmine.createSpy();
-    urlFetcherSpy.and.returnValue(mockResponse(200, {'id': 'fake_token'}));
+    urlFetcherSpy.and.returnValue(mockResponse(200, {id: 'fake_token'}));
   });
 
-  it('should initialize wo token', function() {
+  it('should initialize wo token', function () {
     client = new MetabaseClient(
-      'user', 'pwd', 'url', userPropSpy, urlFetcherSpy,
+      'user',
+      'pwd',
+      'url',
+      userPropSpy,
+      urlFetcherSpy,
     );
     expect(userPropSpy.getKeys).toHaveBeenCalled();
     expect(client.token).toBeUndefined();
   });
 
-  it('should initialize with token', function() {
+  it('should initialize with token', function () {
     userPropSpy.getKeys.and.returnValue(['token']);
     userPropSpy.getProperty.and.returnValue('fake_token');
     client = new MetabaseClient(
-      'user', 'pwd', 'url', userPropSpy, urlFetcherSpy,
+      'user',
+      'pwd',
+      'url',
+      userPropSpy,
+      urlFetcherSpy,
     );
     expect(userPropSpy.getKeys).toHaveBeenCalled();
     expect(client.token).toEqual('fake_token');
   });
 
-  it('should fetch and store token', function() {
+  it('should fetch and store token', function () {
     client = new MetabaseClient(
-      'user', 'pwd', 'url', userPropSpy, urlFetcherSpy,
+      'user',
+      'pwd',
+      'url',
+      userPropSpy,
+      urlFetcherSpy,
     );
     expect(client.token).toBeUndefined();
 
@@ -47,13 +57,17 @@ describe('Client', function() {
     expect(client.token).toEqual('fake_token');
   });
 
-  it('should fetch token as part of fetch', function() {
+  it('should fetch token as part of fetch', function () {
     urlFetcherSpy.and.returnValues(
-      mockResponse(200, {'id': 'fake_token'}),
-      mockResponse(200, {'other': 'payload'}),
+      mockResponse(200, {id: 'fake_token'}),
+      mockResponse(200, {other: 'payload'}),
     );
     client = new MetabaseClient(
-      'user', 'pwd', 'url', userPropSpy, urlFetcherSpy,
+      'user',
+      'pwd',
+      'url',
+      userPropSpy,
+      urlFetcherSpy,
     );
     resp = client.authorizedFetch('www.fake_url.com');
     expect(urlFetcherSpy).toHaveBeenCalledTimes(2);
@@ -61,30 +75,36 @@ describe('Client', function() {
     expect(resp.other).toEqual('payload');
   });
 
-  it('should not fetch token as part of fetch if present', function() {
+  it('should not fetch token as part of fetch if present', function () {
     userPropSpy.getKeys.and.returnValue(['token']);
     userPropSpy.getProperty.and.returnValue('fake_token');
-    urlFetcherSpy.and.returnValues(
-      mockResponse(200, {'other': 'payload'}),
-    );
+    urlFetcherSpy.and.returnValues(mockResponse(200, {other: 'payload'}));
     client = new MetabaseClient(
-      'user', 'pwd', 'url', userPropSpy, urlFetcherSpy,
+      'user',
+      'pwd',
+      'url',
+      userPropSpy,
+      urlFetcherSpy,
     );
     resp = client.authorizedFetch('www.fake_url.com');
     expect(urlFetcherSpy).toHaveBeenCalledTimes(1);
     expect(resp.other).toEqual('payload');
   });
 
-  it('should fetch token as part of fetch if present but expired', function() {
+  it('should fetch token as part of fetch if present but expired', function () {
     userPropSpy.getKeys.and.returnValue(['token']);
     userPropSpy.getProperty.and.returnValue('fake_token');
     urlFetcherSpy.and.returnValues(
       mockResponse(401, {}),
-      mockResponse(200, {'id': 'other_token'}),
-      mockResponse(200, {'other': 'payload'}),
+      mockResponse(200, {id: 'other_token'}),
+      mockResponse(200, {other: 'payload'}),
     );
     client = new MetabaseClient(
-      'user', 'pwd', 'url', userPropSpy, urlFetcherSpy,
+      'user',
+      'pwd',
+      'url',
+      userPropSpy,
+      urlFetcherSpy,
     );
     resp = client.authorizedFetch('www.fake_url.com');
     expect(urlFetcherSpy).toHaveBeenCalledTimes(3);
@@ -101,7 +121,7 @@ describe('Client', function() {
  */
 function mockResponse(statusCode = 200, payload) {
   return {
-    'getResponseCode': () => statusCode,
-    'toString': () => JSON.stringify(payload),
+    getResponseCode: () => statusCode,
+    toString: () => JSON.stringify(payload),
   };
 }

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,11 +1,7 @@
 {
   "spec_dir": "spec",
-  "spec_files": [
-    "**/*[sS]pec.?(m)js"
-  ],
-  "helpers": [
-    "helpers/**/*.?(m)js"
-  ],
+  "spec_files": ["**/*[sS]pec.?(m)js"],
+  "helpers": ["helpers/**/*.?(m)js"],
   "env": {
     "stopSpecOnExpectationFailure": false,
     "random": true


### PR DESCRIPTION
Addresses #12 by extending the scope of the defined `format` and (newly defined) `format_check` commands to include all the files relevant for formatting. This should cover everything that `pretty-quick --staged` covers for now.

There is however a risk that if new files are added that are relevant for formatting and that are not at a location that is currently covered, then the issue will appear again. Currently this is considered not very likely and has low severity even if it happens. There fore the this is not accounted for at this point.